### PR TITLE
Fix #3 wrong liftoff dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "approvals": "0.0.25",
     "chalk": "^0.5.1",
-    "liftoff": "^1.0.3",
+    "liftoff": "^2.0",
     "lodash": "^2.4.1",
     "minimist": "^1.1.0",
     "msee": "^0.1.1",


### PR DESCRIPTION
https://github.com/staxmanade/diffXcodeTargets/issues/3 is caused by an old version of LiftOff. You use `v8flags` which was renamed to `v8flags` in v2.0 of LiftOff